### PR TITLE
Updated auth, post and profile actions (as well as their test files),…

### DIFF
--- a/client/src/actions/__tests__/authActions.js
+++ b/client/src/actions/__tests__/authActions.js
@@ -17,32 +17,33 @@ beforeEach(() => {
 });
 
 describe("registerUser", () => {
-  it('should register the user and redirect to login', async () => {
+  it('should register the user and redirect to login', () => {
     const push = jest.fn();
     const history = { push };
 
-    await store.dispatch(actions.registerUser('the user data', history));
-
-    expect(mock).toHaveBeenCalledWith('/api/users/register', 'the user data');
-    expect(history.push).toHaveBeenCalledWith('/login');
+    return store.dispatch(actions.registerUser('the user data', history))
+      .then(() => {
+        expect(mock).toHaveBeenCalledWith('/api/users/register', 'the user data');
+        expect(history.push).toHaveBeenCalledWith('/login');    
+      });
   });
 });
 
 describe("loginUser", () => {
-  it('should login the user, call localStorage.setItem, then dispatch setCurrentUser', async () => {
-    await store.dispatch(actions.loginUser('the user data'));
-
-    expect(mock).toHaveBeenCalledWith('/api/users/login', 'the user data');
-    expect(localStorage.setItem.mock.calls.length).toBe(1);
-    expect(storeActions[0]).toEqual({ type: types.SET_CURRENT_USER, payload: { exp: 12345 } });
+  it('should login the user, call localStorage.setItem, then dispatch setCurrentUser', () => {
+    return store.dispatch(actions.loginUser('the user data'))
+      .then(() => {
+        expect(mock).toHaveBeenCalledWith('/api/users/login', 'the user data');
+        expect(localStorage.setItem.mock.calls.length).toBe(1);
+        expect(storeActions[0]).toEqual({ type: types.SET_CURRENT_USER, payload: { exp: 12345 } });    
+      });
   });
 });
 
 describe("logoutUser", () => {
   it(`should log user out, call localStorage.removeItem then dispatche user 
-      then dispatch setCurrentUser with empty payload`, async () => {
-      await store.dispatch(actions.logoutUser());
-      
+      then dispatch setCurrentUser with empty payload`, () => {
+      store.dispatch(actions.logoutUser());
       expect(localStorage.removeItem.mock.calls.length).toBe(1);
       expect(storeActions[0]).toEqual({ type: types.SET_CURRENT_USER, payload: {} });
   });

--- a/client/src/actions/__tests__/postActions.js
+++ b/client/src/actions/__tests__/postActions.js
@@ -30,98 +30,121 @@ describe('actions', () => {
 
 describe("getPosts", () => {
   it(`dispatches POST_LOADING and when it resolves and returns POSTS payload, 
-    then it dispatches GET_POSTS`, async () => {
-    await store.dispatch(actions.getPosts());
-    expect(storeActions[0]).toEqual({ type: types.POST_LOADING });
-    expect(storeActions[1]).toEqual({ type: types.GET_POSTS, payload: mockPosts });
+    then it dispatches GET_POSTS`, () => {
+    return store.dispatch(actions.getPosts())
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.POST_LOADING });
+        expect(storeActions[1]).toEqual({ type: types.GET_POSTS, payload: mockPosts });
+      });
   });
 });
 
 describe("addPost", () => {
   it(`dispatches CLEAR_ERRORS and after adding a post and resolving,
     then it dispatches ADD_POST,
-    and returns payload with newly added post`, async () => {
-    await store.dispatch(actions.addPost());
-    expect(storeActions[0]).toEqual({ type: types.CLEAR_ERRORS});
-    expect(storeActions[1]).toEqual({ type: types.ADD_POST, payload: newPost });
+    and returns payload with newly added post`, () => {
+    return store.dispatch(actions.addPost())
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.CLEAR_ERRORS});
+        expect(storeActions[1]).toEqual({ type: types.ADD_POST, payload: newPost });
+      });
   });
 });
 
 describe("deletePost", () => {
-  it("changes dispatches DELETE_POST and when resovled, then payload is id of the deleted post", async () => {
+  it("changes dispatches DELETE_POST and when resovled, then payload is id of the deleted post", () => {
     mockAxios.delete.mockImplementationOnce(() =>
       Promise.resolve({
         data: deletedPostId[0]
       })
     );
 
-    await store.dispatch(actions.deletePost('deletedPostId'));
-    expect(storeActions[0]).toEqual({type: types.DELETE_POST, payload: 'deletedPostId' });
+    return store.dispatch(actions.deletePost('deletedPostId'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.DELETE_POST, payload: 'deletedPostId' });
+      });
   });
 });
 
 describe("addLike", () => {
   it(`adds a 'like', and when resolved, then dispatches getPosts() action
-    (and the actions and payloads that follow that dispatch - POST_LOADING, GET_POSTS).`, async () => {
-    await store.dispatch(actions.addLike('def456'));
-    expect(storeActions[0]).toEqual({type: types.POST_LOADING});
-    expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: mockPosts });
+    (and the actions and payloads that follow that dispatch - POST_LOADING, GET_POSTS).`, () => {
+    return store.dispatch(actions.addLike('def456'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.POST_LOADING});
+        expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: mockPosts });
+      });
   });
 
-  it(`fails, and when it does, then dispatches GET_ERRORS, including null id exception in payload`, async () => {
-    await store.dispatch(actions.deleteLike(null));
-    expect(storeActions[0]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+  it(`fails, and when it does, then dispatches GET_ERRORS, including null id exception in payload`, () => {
+    return store.dispatch(actions.deleteLike(null))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+      });
   });
 });
 
 describe("deleteLike", () => {
   it(`deletes a 'like', and when resolved, then dispatches getPosts() action
-    (and the actions and payloads that follow that dispatch - POST_LOADING, GET_POSTS)`, async () => {
-    await store.dispatch(actions.deleteLike('def456'));
-    expect(storeActions[0]).toEqual({type: types.POST_LOADING});
-    expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: mockPosts });
+    (and the actions and payloads that follow that dispatch - POST_LOADING, GET_POSTS)`, () => {
+    return store.dispatch(actions.deleteLike('def456'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.POST_LOADING});
+        expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: mockPosts });
+      });
   });
 
-  it(`fails, and when it does, then dispatches GET_ERRORS, including null id exception in payload`, async () => {
-    await store.dispatch(actions.deleteLike(null));
-    expect(storeActions[0]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+  it(`fails, and when it does, then dispatches GET_ERRORS, including null id exception in payload`, () => {
+    return store.dispatch(actions.deleteLike(null))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+      });
   });
 });
 
 describe("getPost", () => {
   it(`dispatches POST_LOADING and when resolved, 
-    then dispatches GET_POST, and returns POST payload`, async () => {
-    await store.dispatch(actions.getPost('abc123'));
-    expect(storeActions[0]).toEqual({type: types.POST_LOADING});
-    expect(storeActions[1]).toEqual({type: types.GET_POST, payload: mockPosts[0] });
+    then dispatches GET_POST, and returns POST payload`, () => {
+    return store.dispatch(actions.getPost('abc123'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.POST_LOADING});
+        expect(storeActions[1]).toEqual({type: types.GET_POST, payload: mockPosts[0] });
+      });
   });
 
-  it(`fails, and when it does, then dispatches GET_POSTS, with empty payload`, async () => {
-    await store.dispatch(actions.getPost('nonExistentPostId'));
-    expect(storeActions[0]).toEqual({type: types.POST_LOADING });
-    expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: null });
+  it(`fails, and when it does, then dispatches GET_POSTS, with empty payload`, () => {
+    return store.dispatch(actions.getPost('nonExistentPostId')).then(() => {
+      expect(storeActions[0]).toEqual({type: types.POST_LOADING });
+      expect(storeActions[1]).toEqual({type: types.GET_POSTS, payload: null });
+    });
   });
 });
 
 describe("addComment", () => {
   it(`dispatches CLEAR_ERRORS and then after posting the comment it dispatches GET_POST. 
-    returned payload is updated post including newly added comment`, async () => {
-    await store.dispatch(actions.addComment('def456'));
-    expect(storeActions[0]).toEqual({type: types.CLEAR_ERRORS});
-    expect(storeActions[1]).toEqual({type: types.GET_POST, payload: mockPosts[0] });
+    returned payload is updated post including newly added comment`, () => {
+    return store.dispatch(actions.addComment('def456'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.CLEAR_ERRORS});
+        expect(storeActions[1]).toEqual({type: types.GET_POST, payload: mockPosts[0] });
+      });
   });
 
-  it(`fails, then dispatches GET_POSTS, with empty payload`, async () => {
-    await store.dispatch(actions.addComment('nonExistentPostId'));
-    expect(storeActions[0]).toEqual({type: types.CLEAR_ERRORS });
-    expect(storeActions[1]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+  it(`fails, then dispatches GET_POSTS, with empty payload`, () => {
+    return store.dispatch(actions.addComment('nonExistentPostId'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({type: types.CLEAR_ERRORS });
+        expect(storeActions[1]).toEqual({type: types.GET_ERRORS, payload: idCannotBeNullExceptionMessage });
+      });
   });
 });
 
 describe("deleteComment", () => {
   it(`deletes specified comment for given post, then dispatches GET_POST. 
-    returned payload is updated post reflecting removed comment`, async () => {
-    await store.dispatch(actions.deleteComment('def456', 'pqr789'));
-    expect(storeActions[0]).toEqual({ type: types.GET_POST, payload: deletedPostId[0] });
+    returned payload is updated post reflecting removed comment`, () => {
+    return store.dispatch(actions.deleteComment('def456', 'pqr789'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.GET_POST, payload: deletedPostId[0] });
+      });
   });
 });

--- a/client/src/actions/__tests__/profileActions.js
+++ b/client/src/actions/__tests__/profileActions.js
@@ -29,86 +29,104 @@ describe('profileActions: mocking history', () => {
   });
 
   describe('createProfile', () => {
-    it(`should create profile by calling '/api/profiles', then push /dashboard to history`, async () => {
-      await actions.createProfile('the profile data', history)(dispatch);
-      expect(mock).toHaveBeenCalledWith('/api/profiles', 'the profile data');
-      expect(history.push).toHaveBeenCalledWith('/dashboard');
+    it(`should create profile by calling '/api/profiles', then push /dashboard to history`, () => {
+      actions.createProfile('the profile data', history)(dispatch)
+        .then(() => {
+          expect(mock).toHaveBeenCalledWith('/api/profiles', 'the profile data');
+          expect(history.push).toHaveBeenCalledWith('/dashboard');
+        });
     });
   });
 
   describe('addEducation', () => {
-    it('should create education then push /dashboard to history', async () => {
-      await actions.addEducation('the education data', history)(dispatch);
-      expect(mock).toHaveBeenCalledWith('/api/profiles/education', 'the education data');
-      expect(history.push).toHaveBeenCalledWith('/dashboard');
+    it('should create education then push /dashboard to history', () => {
+      actions.addEducation('the education data', history)(dispatch)
+        .then(() => {
+          expect(mock).toHaveBeenCalledWith('/api/profiles/education', 'the education data');
+          expect(history.push).toHaveBeenCalledWith('/dashboard');
+        });
     });
   });
 
   describe('addExperience', () => {
-    it('should create education then push /dashboard to history', async () => {
-      await actions.addExperience('the experience data', history)(dispatch);
-      expect(mock).toHaveBeenCalledWith('/api/profiles/experience', 'the experience data');
-      expect(history.push).toHaveBeenCalledWith('/dashboard');
+    it('should create education then push /dashboard to history', () => {
+      actions.addExperience('the experience data', history)(dispatch)
+        .then(() => {
+          expect(mock).toHaveBeenCalledWith('/api/profiles/experience', 'the experience data');
+          expect(history.push).toHaveBeenCalledWith('/dashboard');
+        });
     });
   });
 
 });
 
 describe('getCurrentProfile', () => {
-  it('dispatches setProfileLoading, then dispatches GET_PROFILE', async () => {
-    await store.dispatch(actions.getCurrentProfile());
-    expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING});
-    expect(storeActions[1]).toEqual({ type: types.GET_PROFILE, payload: {} });
+  it('dispatches setProfileLoading, then dispatches GET_PROFILE', () => {
+    return store.dispatch(actions.getCurrentProfile())
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING});
+        expect(storeActions[1]).toEqual({ type: types.GET_PROFILE, payload: {} });
+      });
   });
 });
 
 describe('deleteEducation', () => {
-  it('should delete education then dispatch GET_PROFILE', async () => {
-    await store.dispatch(actions.deleteEducation('edu123'));
-    expect(storeActions[0]).toEqual({ type: types.GET_PROFILE, payload: {}});
+  it('should delete education then dispatch GET_PROFILE', () => {
+    return store.dispatch(actions.deleteEducation('edu123'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.GET_PROFILE, payload: {}});
+      });
   });
 });
 
 describe('deleteExperience', () => {
-  it('should delete experience then dispatch GET_PROFILE', async () => {
-    await store.dispatch(actions.deleteExperience('exp123'));
-    expect(storeActions[0]).toEqual({ type: types.GET_PROFILE, payload: {}});
+  it('should delete experience then dispatch GET_PROFILE', () => {
+    return store.dispatch(actions.deleteExperience('exp123'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.GET_PROFILE, payload: {}});
+      });
   });
 });
 
 describe('getProfiles', () => {
-  it('should dispatch setProfileLoading then dispatch GET_PROFILES with data in the payload after successful callback from the endpoint', async () => {
-    await store.dispatch(actions.getProfiles());
-    expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING });
-    expect(storeActions[1]).toEqual({ type: types.GET_PROFILES, payload: ['profile1, profile2, profile3'] });
+  it('should dispatch setProfileLoading then dispatch GET_PROFILES with data in the payload after successful callback from the endpoint', () => {
+    return store.dispatch(actions.getProfiles())
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING });
+        expect(storeActions[1]).toEqual({ type: types.GET_PROFILES, payload: ['profile1, profile2, profile3'] });
+      });
   });
 });
 
 describe('getProfileByHandle', () => {
-  it('should dispatch setProfileLoading then dispatch GET_PROFILE with data in the payload after successful callback from the endpoint', async () => {
-    await store.dispatch(actions.getProfileByHandle('user123'));
-    expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING });
-    expect(storeActions[1]).toEqual({ type: types.GET_PROFILE, payload: 'fakeProfile' });
+  it('should dispatch setProfileLoading then dispatch GET_PROFILE with data in the payload after successful callback from the endpoint', () => {
+    return store.dispatch(actions.getProfileByHandle('user123'))
+      .then(() => {
+        expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING });
+        expect(storeActions[1]).toEqual({ type: types.GET_PROFILE, payload: 'fakeProfile' });
+      });
   });
 });
 
 describe('deleteAccount', () => {
-  it('should dispatch SET_CURRENT_USER with empty payload after successful callback from the endpoint', async () => {
-    await store.dispatch(actions.deleteAccount());
-    expect(storeActions[0]).toEqual({ type: types.SET_CURRENT_USER, payload: {} });
+  it('should dispatch SET_CURRENT_USER with empty payload after successful callback from the endpoint', () => {
+    return store.dispatch(actions.deleteAccount())
+    .then(() => {
+      expect(storeActions[0]).toEqual({ type: types.SET_CURRENT_USER, payload: {} });
+    });
   });
 });
 
 describe('setProfileLoading', () => {
-  it('should dispatch PROFILE_LOADING', async () => {
-    await store.dispatch(actions.setProfileLoading());
+  it('should dispatch PROFILE_LOADING', () => {
+    store.dispatch(actions.setProfileLoading());
     expect(storeActions[0]).toEqual({ type: types.PROFILE_LOADING });
   });
 });
 
 describe('clearCurrentProfile', () => {
-  it('should dispatch CLEAR_CURRENT_PROFILE', async () => {
-    await store.dispatch(actions.clearCurrentProfile());
+  it('should dispatch CLEAR_CURRENT_PROFILE', () => {
+    store.dispatch(actions.clearCurrentProfile());
     expect(storeActions[0]).toEqual({ type: types.CLEAR_CURRENT_PROFILE });
   });
 });

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -4,8 +4,8 @@ import setTokenAsHeader from '../utils/setTokenAsHeader';
 import jwt_decode from 'jwt-decode';
 
 // reg user
-export const registerUser = (userData, history) => async (dispatch) => {
-  await axios
+export const registerUser = (userData, history) => dispatch => {
+  return axios
     .post('/api/users/register', userData)
     .then(() => history.push('/login'))
     .catch(err =>
@@ -17,8 +17,8 @@ export const registerUser = (userData, history) => async (dispatch) => {
 };
 
 // login and grab token, then attach to future headers
-export const loginUser = userData => async (dispatch) => {
-  await axios
+export const loginUser = userData => dispatch => {
+  return axios
     .post('/api/users/login', userData)
     .then(res => {
       let { token } = res.data;

--- a/client/src/actions/postActions.js
+++ b/client/src/actions/postActions.js
@@ -9,9 +9,9 @@ import {
   POST_LOADING
 } from './types';
 
-export const addPost = postData => async (dispatch) => {
+export const addPost = postData => dispatch => {
   dispatch(clearErrors());
-  await axios
+  return axios
     .post('/api/posts', postData)
     .then(res =>
       dispatch({
@@ -27,9 +27,9 @@ export const addPost = postData => async (dispatch) => {
     );
 };
 
-export const getPosts = () => async (dispatch) => {
+export const getPosts = () => dispatch => {
   dispatch(setPostLoading());
-  await axios
+  return axios
     .get('/api/posts')
     .then(res =>
       dispatch({
@@ -45,8 +45,8 @@ export const getPosts = () => async (dispatch) => {
     );
 };
 
-export const deletePost = id => async (dispatch) => {
-  await axios
+export const deletePost = id => dispatch => {
+  return axios
     .delete(`/api/posts/${id}`)
     .then(res =>
       dispatch({
@@ -62,8 +62,8 @@ export const deletePost = id => async (dispatch) => {
     );
 };
 
-export const addLike = id => async (dispatch) => {
-  await axios
+export const addLike = id => dispatch => {
+  return axios
     .post(`/api/posts/like/${id}`)
     .then(res => dispatch(getPosts()))
     .catch(err =>
@@ -74,8 +74,8 @@ export const addLike = id => async (dispatch) => {
     );
 };
 
-export const deleteLike = id => async (dispatch) => {
-  await axios
+export const deleteLike = id => dispatch => {
+  return axios
     .post(`/api/posts/unlike/${id}`)
     .then(res => dispatch(getPosts()))
     .catch(err =>
@@ -86,9 +86,9 @@ export const deleteLike = id => async (dispatch) => {
     );
 };
 
-export const getPost = id => async (dispatch) => {
+export const getPost = id => dispatch => {
   dispatch(setPostLoading());
-  await axios
+  return axios
     .get(`/api/posts/${id}`)
     .then(res =>
       dispatch({
@@ -104,9 +104,9 @@ export const getPost = id => async (dispatch) => {
     );
 };
 
-export const addComment = (postId, comment) => async (dispatch) => {
+export const addComment = (postId, comment) => dispatch => {
   dispatch(clearErrors());
-  await axios
+  return axios
     .post(`/api/posts/comment/${postId}`, comment)
     .then(res =>
       dispatch({
@@ -122,8 +122,8 @@ export const addComment = (postId, comment) => async (dispatch) => {
     );
 };
 
-export const deleteComment = (postId, commentId) => async (dispatch) => {
-  await axios
+export const deleteComment = (postId, commentId) => dispatch => {
+  return axios
     .delete(`/api/posts/comment/${postId}/${commentId}`)
     .then(res =>
       dispatch({

--- a/client/src/actions/profileActions.js
+++ b/client/src/actions/profileActions.js
@@ -9,9 +9,9 @@ import {
   SET_CURRENT_USER
 } from './types';
 
-export const getCurrentProfile = () => async (dispatch) => {
+export const getCurrentProfile = () => dispatch => {
   dispatch(setProfileLoading());
-  await axios
+  return axios
     .get('/api/profiles')
     .then(res =>
       dispatch({
@@ -27,8 +27,8 @@ export const getCurrentProfile = () => async (dispatch) => {
     );
 };
 
-export const createProfile = (profileData, history) => async (dispatch) => {
-  await axios
+export const createProfile = (profileData, history) => dispatch => {
+  return axios
     .post('/api/profiles', profileData)
     .then(res => history.push('/dashboard'))
     .catch(err =>
@@ -39,8 +39,8 @@ export const createProfile = (profileData, history) => async (dispatch) => {
     );
 };
 
-export const addEducation = (eduData, history) => async (dispatch) => {
-  await axios
+export const addEducation = (eduData, history) => dispatch => {
+  return axios
     .post('/api/profiles/education', eduData)
     .then(res => history.push('/dashboard'))
     .catch(err =>
@@ -51,14 +51,13 @@ export const addEducation = (eduData, history) => async (dispatch) => {
     );
 };
 
-export const deleteEducation = id => async (dispatch) => {
-  await axios
+export const deleteEducation = id => dispatch => {
+  return axios
     .delete(`/api/profiles/education/${id}`)
     .then(res =>
       dispatch({
         type: GET_PROFILE,
-        // remember server returns the updated profile minus the education that was deleted
-        // rather than pushing to our history, we will use the difference in returned object state to updated the view
+        // returns updated profile minus the education that was deleted
         payload: res.data
       })
     )
@@ -70,8 +69,8 @@ export const deleteEducation = id => async (dispatch) => {
     );
 };
 
-export const addExperience = (expData, history) => async (dispatch) => {
-  await axios
+export const addExperience = (expData, history) => dispatch => {
+  return axios
     .post('/api/profiles/experience', expData)
     .then(res => history.push('/dashboard'))
     .catch(err =>
@@ -82,9 +81,9 @@ export const addExperience = (expData, history) => async (dispatch) => {
     );
 };
 
-export const getProfiles = () => async (dispatch) => {
+export const getProfiles = () => dispatch => {
   dispatch(setProfileLoading());
-  await axios
+  return axios
     .get('/api/profiles/all')
     .then(res =>
       dispatch({
@@ -100,9 +99,9 @@ export const getProfiles = () => async (dispatch) => {
     );
 };
 
-export const getProfileByHandle = handle => async (dispatch) => {
+export const getProfileByHandle = handle => dispatch => {
   dispatch(setProfileLoading());
-  await axios
+  return axios
     .get(`/api/profiles/handle/${handle}`)
     .then(res =>
       dispatch({
@@ -118,14 +117,13 @@ export const getProfileByHandle = handle => async (dispatch) => {
     );
 };
 
-export const deleteExperience = id => async (dispatch) => {
-  await axios
+export const deleteExperience = id => dispatch => {
+  return axios
     .delete(`/api/profiles/experience/${id}`)
     .then(res =>
       dispatch({
         type: GET_PROFILE,
-        // remember server returns the updated profile minus the experience that was deleted
-        // rather than pushing to our history, we will use the difference in returned object state to updated the view
+        // returns updated profile minus the experience that was deleted
         payload: res.data
       })
     )
@@ -137,8 +135,8 @@ export const deleteExperience = id => async (dispatch) => {
     );
 };
 
-export const deleteAccount = () => async (dispatch) => {
-  await axios
+export const deleteAccount = () => dispatch => {
+  return axios
     .delete('/api/profiles')
     .then(res =>
       dispatch({


### PR DESCRIPTION
… so that we're NOT using async await. Prior to this change, we were not correctly using async await (we were acting on the return of a promis eby using then()), hence the syntax is misleading at this time.